### PR TITLE
Fix for mixed reading

### DIFF
--- a/Sources/BinaryKit/Binary.swift
+++ b/Sources/BinaryKit/Binary.swift
@@ -42,9 +42,9 @@ public struct Binary {
         }
         self.init(bytes: bytes)
     }
+
     
-    
-    
+
     // MARK: - Cursor
     
     /// Returns an `Int` with the value of `readBitCursor` incremented by `bits`.
@@ -95,7 +95,7 @@ public struct Binary {
     }
     
     /// Returns the `Int`-value of the given range.
-    public mutating func getBits(range: Range<Int>) throws -> Int {
+    public func getBits(range: Range<Int>) throws -> Int {
         // Check if the request is within bounds
         let storeRange = 0...(bytesStore.count * byteSize)
         guard storeRange.contains(range.endIndex) else {
@@ -166,17 +166,19 @@ public struct Binary {
     /// Returns the `UInt8`-value of the next byte and
     /// increments the reading cursor by 1 byte.
     public mutating func readByte() throws -> UInt8 {
-        let result = try getByte(index: readBitCursor / byteSize)
-        incrementReadCursorBy(bytes: 1)
-        return result
+        return UInt8(try readBits(byteSize))
     }
     
     /// Returns a `[UInt8]` of the next n-bytes (`quantitiy`) and
     /// increments the reading cursor by n-bytes.
     public mutating func readBytes(_ quantitiy: Int) throws -> [UInt8] {
-        let readByteCursor = readBitCursor / byteSize
-        incrementReadCursorBy(bytes: quantitiy)
-        return try getBytes(range: readByteCursor..<(readByteCursor + quantitiy))
+        // Check if the request is within bounds
+        let range = (readBitCursor..<(readBitCursor + quantitiy * byteSize))
+        let storeRange = 0...(bytesStore.count * byteSize)
+        guard storeRange.contains(range.endIndex) else {
+            throw BinaryError.outOfBounds
+        }
+        return try (0..<quantitiy).map{ _ in try readByte() }
     }
     
     public mutating func readBytes(_ quantitiy: UInt8) throws -> [UInt8] {

--- a/Tests/BinaryKitTests/BinaryKitTests.swift
+++ b/Tests/BinaryKitTests/BinaryKitTests.swift
@@ -111,7 +111,7 @@ final class BinaryKitTests: XCTestCase {
 
     // MARK: - Mixed Reading
 
-    func testReadBitReadByte() {
+    func testMixedReadByte() {
         let bytes: [UInt8] = [0b1010_1101, 0b1010_1111]
         var bin = Binary(bytes: bytes)
 
@@ -120,7 +120,7 @@ final class BinaryKitTests: XCTestCase {
         XCTAssertEqual(bin.readBitCursor, 9)
     }
 
-    func testReadBitReadBytes() {
+    func testMixedReadBytes() {
         let bytes: [UInt8] = [0b1010_1101, 0b1010_1111, 0b1000_1101]
         var bin = Binary(bytes: bytes)
 
@@ -129,7 +129,7 @@ final class BinaryKitTests: XCTestCase {
         XCTAssertEqual(bin.readBitCursor, 17)
     }
 
-    func testThrowsBeforeActualRead() {
+    func testReadBytesThrowsBeforeReading() {
         let bytes: [UInt8] = [0b1010_1101, 0b1010_1111, 0b1000_1101]
         var bin = Binary(bytes: bytes)
 
@@ -139,16 +139,7 @@ final class BinaryKitTests: XCTestCase {
         XCTAssertEqual(bin.readBitCursor, 1)
     }
 
-    func testThrowsBeforeAcutalRead1() {
-        let bytes: [UInt8] = [0b1010_1101, 0b1010_1111, 0b1000_1101]
-        var bin = Binary(bytes: bytes)
-
-        XCTAssertEqual(bin.readBitCursor, 0)
-        XCTAssertThrowsError(try bin.readBytes(4))
-        XCTAssertEqual(bin.readBitCursor, 0)
-    }
-
-    func testThrowsBeforeAcutalRead2() {
+    func testReadBitsThrowsBeforeReading() {
         let bytes: [UInt8] = [0b1010_1101, 0b1010_1111, 0b1000_1101]
         var bin = Binary(bytes: bytes)
 

--- a/Tests/BinaryKitTests/BinaryKitTests.swift
+++ b/Tests/BinaryKitTests/BinaryKitTests.swift
@@ -79,7 +79,7 @@ final class BinaryKitTests: XCTestCase {
         XCTAssertEqual(try bin.readByte(), 173)
         XCTAssertEqual(try bin.readByte(), 175)
     }
-    
+
     func testByteIndex() {
         let bytes: [UInt8] = [0b1010_1101, 0b1010_1111]
         let bin = Binary(bytes: bytes)
@@ -108,7 +108,55 @@ final class BinaryKitTests: XCTestCase {
         XCTAssertEqual(try bin.getBytes(range: 0..<2), [173, 175])
         XCTAssertThrowsError(try bin.getBytes(range: 2..<3))
     }
-    
+
+    // MARK: - Mixed Reading
+
+    func testReadBitReadByte() {
+        let bytes: [UInt8] = [0b1010_1101, 0b1010_1111]
+        var bin = Binary(bytes: bytes)
+
+        XCTAssertEqual(try bin.readBit(), 1)
+        XCTAssertEqual(try bin.readByte(), 91)
+        XCTAssertEqual(bin.readBitCursor, 9)
+    }
+
+    func testReadBitReadBytes() {
+        let bytes: [UInt8] = [0b1010_1101, 0b1010_1111, 0b1000_1101]
+        var bin = Binary(bytes: bytes)
+
+        XCTAssertEqual(try bin.readBit(), 1)
+        XCTAssertEqual(try bin.readBytes(2), [UInt8(91),UInt8(95)])
+        XCTAssertEqual(bin.readBitCursor, 17)
+    }
+
+    func testThrowsBeforeActualRead() {
+        let bytes: [UInt8] = [0b1010_1101, 0b1010_1111, 0b1000_1101]
+        var bin = Binary(bytes: bytes)
+
+        XCTAssertEqual(try bin.readBit(), 1)
+        XCTAssertEqual(bin.readBitCursor, 1)
+        XCTAssertThrowsError(try bin.readBytes(3))
+        XCTAssertEqual(bin.readBitCursor, 1)
+    }
+
+    func testThrowsBeforeAcutalRead1() {
+        let bytes: [UInt8] = [0b1010_1101, 0b1010_1111, 0b1000_1101]
+        var bin = Binary(bytes: bytes)
+
+        XCTAssertEqual(bin.readBitCursor, 0)
+        XCTAssertThrowsError(try bin.readBytes(4))
+        XCTAssertEqual(bin.readBitCursor, 0)
+    }
+
+    func testThrowsBeforeAcutalRead2() {
+        let bytes: [UInt8] = [0b1010_1101, 0b1010_1111, 0b1000_1101]
+        var bin = Binary(bytes: bytes)
+
+        XCTAssertEqual(bin.readBitCursor, 0)
+        XCTAssertThrowsError(try bin.readBits(100))
+        XCTAssertEqual(bin.readBitCursor, 0)
+    }
+
     // MARK: - Init
     
     func testHexInit() {
@@ -204,12 +252,14 @@ final class BinaryKitTests: XCTestCase {
         XCTAssertEqual(try bin.readBit(), 1)
         XCTAssertEqual(try bin.readBit(), 1)
         XCTAssertEqual(try bin.readBit(), 1)
+
         XCTAssertEqual(try bin.readBit(), 1)
         XCTAssertEqual(try bin.readBit(), 1)
         XCTAssertEqual(try bin.readBit(), 1)
         XCTAssertEqual(try bin.readBit(), 1)
-        XCTAssertEqual(try bin.readBit(), 1)
+
         XCTAssertEqual(try bin.readByte(), 128)
+
         XCTAssertEqual(try bin.readByte(), 7)
         XCTAssertEqual(try bin.readByte(), 128)
         XCTAssertEqual(try bin.readString(quantitiyOfBytes: 12), "hello world!")


### PR DESCRIPTION
Fixes #15 -  mixed reading error:
* remove redundant `mutating` keyword from `getBits` method
* change `readByte` and `readBytes` methods
* add unit tests